### PR TITLE
Fixed problem with attributed text.

### DIFF
--- a/SwiftStylish/Core/StyleValue.swift
+++ b/SwiftStylish/Core/StyleValue.swift
@@ -849,7 +849,9 @@ extension StyleValue
             throw StyleValueError.missingRequiredParameter(name: "text", forTypeValue: "attributed-string")
         }
         
-        let attributedString = NSMutableAttributedString(string: text)
+        let localizedString = try StyleValue(value: text, bundle: self.bundle, variables: self.variables).toLocalizedString()
+        
+        let attributedString = NSMutableAttributedString(string: localizedString)
         
         guard let attrs = params["attributes"] else
         {


### PR DESCRIPTION
If the range of localized string will be more than text, there will be exception